### PR TITLE
Update sls to v1.26.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Rupak Ganguly <rupakg@gmail.com>"
 RUN apt-get update && \ 
     apt-get install python-dev -y && \ 
     apt-get clean
-RUN npm install -g serverless@1.25.0 && \ 
+RUN npm install -g serverless@1.26.1 && \ 
     curl -O https://bootstrap.pypa.io/get-pip.py 
 RUN python get-pip.py 
 RUN pip install awscli


### PR DESCRIPTION
I ran into this issue recently: https://github.com/serverless/serverless/pull/3297, where executing a `sls remove` on a project would stall. 

Updating to `sls v1.26.1` solves the issue.